### PR TITLE
feat(web): add proxy support with validation and transport setup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,4 +6,5 @@ require (
 	github.com/BurntSushi/toml v1.5.0 // indirect
 	github.com/Syfaro/telegram-bot-api v4.6.4+incompatible // indirect
 	github.com/technoweenie/multipartstreamer v1.0.1 // indirect
+	golang.org/x/net v0.39.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,3 +4,5 @@ github.com/Syfaro/telegram-bot-api v4.6.4+incompatible h1:O30CgxZ/BuHpWfONoGirTI
 github.com/Syfaro/telegram-bot-api v4.6.4+incompatible/go.mod h1:eC/lEGT3gOB9RowMYsLx0YH1U8a/dEjceHY3M//ej88=
 github.com/technoweenie/multipartstreamer v1.0.1 h1:XRztA5MXiR1TIRHxH2uNxXxaIkKQDeX7m2XsSOlQEnM=
 github.com/technoweenie/multipartstreamer v1.0.1/go.mod h1:jNVxdtShOxzAsukZwTSw6MDx5eUJoiEBsSvzDU9uzog=
+golang.org/x/net v0.39.0 h1:ZCu7HMWDxpXpaiKdhzIfaltL9Lp31x/3fCP11bc6/fY=
+golang.org/x/net v0.39.0/go.mod h1:X7NRbYVEA+ewNkCNyJ513WmMdQ3BineSwVtN2zD/d+E=

--- a/web/parseurl.go
+++ b/web/parseurl.go
@@ -1,0 +1,33 @@
+package web
+
+import (
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+func isValidUrlOrAddr(input string) bool {
+	if u, err := url.Parse(input); err == nil && u.Scheme != "" && u.Host != "" {
+		return true
+	}
+
+	host, port, err := net.SplitHostPort(input)
+	if err != nil {
+		return false
+	}
+
+	if portNum, err := strconv.Atoi(port); err != nil || portNum < 0 || portNum > 65535 {
+		return false
+	}
+
+	if ip := net.ParseIP(host); ip != nil {
+		return true
+	}
+
+	if strings.Contains(host, ".") {
+		return true
+	}
+
+	return false
+}

--- a/web/webtransport.go
+++ b/web/webtransport.go
@@ -1,0 +1,50 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"golang.org/x/net/proxy"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+func GetWebTransport(proxyAddress string) (*http.Transport, error) {
+	isValidProxy := isValidUrlOrAddr(proxyAddress)
+	if !isValidProxy {
+		return nil, errors.New("invalid proxy address")
+	}
+
+	if !strings.Contains(proxyAddress, "://") {
+		proxyAddress = "http://" + proxyAddress
+	}
+
+	parsedURL, err := url.Parse(proxyAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	var transport *http.Transport
+
+	switch parsedURL.Scheme {
+	case "http", "https":
+		transport = &http.Transport{
+			Proxy: http.ProxyURL(parsedURL),
+		}
+	case "socks5", "socks5h":
+		dialer, proxyErr := proxy.FromURL(parsedURL, proxy.Direct)
+		if proxyErr != nil {
+			return nil, err
+		}
+		transport = &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				return dialer.Dial(network, addr)
+			},
+		}
+	default:
+		return nil, errors.New("unsupported proxy scheme: " + parsedURL.Scheme)
+	}
+
+	return transport, nil
+}


### PR DESCRIPTION
Introduce isValidUrlOrAddr to validate URLs and host:port addresses,
ensuring proxy addresses are correctly formatted. Implement GetWebTransport
to create an http.Transport configured for HTTP, HTTPS, or SOCKS5 proxies.
This enables flexible proxy usage with proper error handling and scheme support.