### PR TITLE
test: improve error handling and add URL validation tests

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"TelegramSiteMonitorBot/config"
+	"TelegramSiteMonitorBot/telegram"
+	"TelegramSiteMonitorBot/web"
+	"bytes"
+	"errors"
+	"flag"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Mock
+type MockBot struct {
+	Token  string
+	ChatID int
+}
+
+func (m *MockBot) SendMessage(message string) error {
+	if message == "" {
+		return errors.New("пустое сообщение")
+	}
+	return nil
+}
+
+func (m *MockBot) Updates() <-chan telegram.Update {
+	return nil
+}
+
+func MockNewBot(token string, chatID int) (telegram.Bot, error) {
+	if token == "" || chatID == 0 {
+		return nil, errors.New("incorrect parameters")
+	}
+	return &MockBot{Token: token, ChatID: chatID}, nil
+}
+
+type mockRoundTripper struct {
+	StatusCode   int
+	ErrorToThrow error
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	if m.ErrorToThrow != nil {
+		return nil, m.ErrorToThrow
+	}
+	return &http.Response{
+		StatusCode: m.StatusCode,
+		Body:       io.NopCloser(strings.NewReader("ok")),
+		Header:     make(http.Header),
+	}, nil
+}
+
+var mockConfig = `
+[telegram]  
+bot_token = "YOUR_TELEGRAM_BOT_TOKEN"  
+chat_id = 123456789  
+
+[sites]  
+urls = [  
+  "https://example.com",  
+  "https://google.com",  
+]  
+
+[settings]  
+check_interval = 300
+timeout = 10
+`
+
+func TestParseFlags(t *testing.T) {
+	tests := []struct {
+		args     []string
+		expected string
+	}{
+		{[]string{"cmd", "-path=test_config.toml"}, "test_config.toml"},
+		{[]string{"cmd", "-p=short_config.toml"}, "short_config.toml"},
+		{[]string{"cmd"}, "config.toml"},
+	}
+
+	for _, tt := range tests {
+
+		os.Args = tt.args
+		flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+		parseFlags()
+
+		if config.PathToConfig != tt.expected {
+			t.Errorf("expected %v, received %v", tt.expected, config.PathToConfig)
+		}
+	}
+}
+
+func TestPerformRequests_SuccessResponse(t *testing.T) {
+	tempConfig, err := os.CreateTemp("", "testConfig.toml")
+	if err != nil {
+		t.Fatalf("error creating temporary file: %v", err)
+	}
+	defer func(name string) {
+		removeErr := os.Remove(name)
+		if removeErr != nil {
+			t.Fatal(removeErr.Error())
+		}
+	}(tempConfig.Name())
+	_, writeConfigErr := tempConfig.Write([]byte(mockConfig))
+	if writeConfigErr != nil {
+		t.Fatalf("error writing to file: %v\n", writeConfigErr)
+	}
+	closeFileError := tempConfig.Close()
+	if closeFileError != nil {
+		t.Fatalf("close file error %v", closeFileError)
+	}
+	config.PathToConfig = tempConfig.Name()
+	cfg := &config.AppConfig{}
+	client := &http.Client{
+		Transport: &mockRoundTripper{
+			StatusCode: 200,
+		},
+	}
+	logCh := make(chan web.Response, 2)
+	errCh := make(chan web.Response, 2)
+
+	performRequests(cfg, client, logCh, errCh)
+	time.Sleep(100 * time.Millisecond)
+
+	if len(logCh) != 2 {
+		t.Errorf("Expected 2 log responses, got %d", len(logCh))
+	}
+	if len(errCh) != 0 {
+		t.Errorf("Expected 0 error responses, got %d", len(errCh))
+	}
+}
+
+// Tests
+func TestPerformRequests_ErrorResponse(t *testing.T) {
+	tempConfig, err := os.CreateTemp("", "testConfig.toml")
+	if err != nil {
+		t.Fatalf("error creating temporary file: %v", err)
+	}
+	defer func(name string) {
+		removeErr := os.Remove(name)
+		if removeErr != nil {
+			t.Fatal(removeErr.Error())
+		}
+	}(tempConfig.Name())
+	_, writeConfigErr := tempConfig.Write([]byte(mockConfig))
+	if writeConfigErr != nil {
+		t.Fatalf("error writing to file: %v\n", writeConfigErr)
+	}
+	closeFileError := tempConfig.Close()
+	if closeFileError != nil {
+		t.Fatalf("close file error %v", closeFileError)
+	}
+	config.PathToConfig = tempConfig.Name()
+	cfg := &config.AppConfig{}
+	client := &http.Client{
+		Transport: &mockRoundTripper{
+			StatusCode: 500,
+		},
+	}
+	logCh := make(chan web.Response, 2)
+	errCh := make(chan web.Response, 2)
+
+	performRequests(cfg, client, logCh, errCh)
+	time.Sleep(100 * time.Millisecond)
+
+	if len(logCh) != 2 {
+		t.Errorf("Expected 2 log responses, got %d", len(logCh))
+	}
+	if len(errCh) != 2 {
+		t.Errorf("Expected 2 error responses, got %d", len(errCh))
+	}
+}
+
+func TestPerformRequests_UpdateError(t *testing.T) {
+	var logBuf bytes.Buffer
+	log.SetOutput(&logBuf)
+	defer log.SetOutput(os.Stderr)
+	config.PathToConfig = "tempConfig.Name()"
+	cfg := &config.AppConfig{}
+	client := &http.Client{
+		Transport: &mockRoundTripper{
+			StatusCode: 500,
+		},
+	}
+	logCh := make(chan web.Response, 2)
+	errCh := make(chan web.Response, 2)
+
+	performRequests(cfg, client, logCh, errCh)
+	time.Sleep(100 * time.Millisecond)
+
+	if logBuf.String() == "" {
+		t.Errorf("Expected error in log")
+	}
+}

--- a/telegram/handle_test.go
+++ b/telegram/handle_test.go
@@ -4,12 +4,11 @@ import (
 	"TelegramSiteMonitorBot/config"
 	"TelegramSiteMonitorBot/web"
 	"bytes"
-	"fmt"
+	"errors"
 	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -44,13 +43,7 @@ func (m *MockBot) Updates() <-chan Update {
 // Helper function for tests
 func newTestConfig(URLs []string) *config.AppConfig {
 	cfg := config.AppConfig{}
-	val := reflect.ValueOf(&cfg.Sites).Elem()
-	urlsField := val.FieldByName("URLs")
-	if urlsField.CanSet() {
-		urlsField.Set(reflect.ValueOf(URLs))
-	} else {
-		panic("URLs field is not editable")
-	}
+	cfg.Sites.URLs = URLs
 	return &cfg
 }
 
@@ -83,7 +76,7 @@ func TestHandleWebResponses_Error(t *testing.T) {
 	defer close(responsesCh)
 	var wg sync.WaitGroup
 	bot := &MockBot{
-		ErrToThrow: fmt.Errorf("error"),
+		ErrToThrow: errors.New("error"),
 		Done: func() {
 			wg.Done()
 		},
@@ -185,7 +178,7 @@ func TestHandleStatusCommand_MessageInCh(t *testing.T) {
 
 func TestHandleStatusCommand_Error(t *testing.T) {
 	bot := &MockBot{
-		ErrToThrow: fmt.Errorf("error"),
+		ErrToThrow: errors.New("error"),
 		Done: func() {
 			return
 		},
@@ -226,7 +219,7 @@ func TestHandleUnknownCommand_Error(t *testing.T) {
 	log.SetOutput(&logBuf)
 	defer log.SetOutput(os.Stderr)
 	bot := &MockBot{}
-	bot.ErrToThrow = fmt.Errorf("error")
+	bot.ErrToThrow = errors.New("error")
 
 	handleUnknownCommand(bot)
 

--- a/web/parseurl_test.go
+++ b/web/parseurl_test.go
@@ -1,0 +1,33 @@
+package web
+
+import "testing"
+
+func TestIsValidUrlOrAddr(t *testing.T) {
+	tests := []struct {
+		urlOrAddr string
+		expected  bool
+	}{
+		{"http://example.com", true},
+		{"https://google.com", true},
+		{"socks5://127.0.0.1", true},
+		{"socks5h://122.2.2.1", true},
+		{"ftp://server.local", true},
+		{"example", false},
+		{"1234567890", false},
+		{"localhost:8080", false},
+		{"127.0.0.1", false},
+		{"sub.domain.com:8080", true},
+		{"127.0.0.1:8080", true},
+		{"example.com", false},
+		{"google.com", false},
+		{"127.0.0.1:8080:8081", false},
+		{"127.0.0.1:80800", false},
+		{"134.45.234.1:-1", false},
+	}
+
+	for _, tt := range tests {
+		if isValidUrlOrAddr(tt.urlOrAddr) != tt.expected {
+			t.Errorf("expected %v, received %v (%v)", tt.expected, isValidUrlOrAddr(tt.urlOrAddr), tt.urlOrAddr)
+		}
+	}
+}

--- a/web/webtransport_test.go
+++ b/web/webtransport_test.go
@@ -1,0 +1,104 @@
+package web
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGetWebTransport_Http_HttpTransport(t *testing.T) {
+	transport, err := GetWebTransport("http://127.0.0.1")
+	if err != nil {
+		t.Fatalf("error getting web transport: %v", err)
+	}
+	if transport == nil {
+		t.Error("transport is nil")
+	}
+	if transport.Proxy == nil {
+		t.Error("proxy is nil")
+	}
+	if transport.DialContext != nil {
+		t.Error("dial context is not nil")
+	}
+}
+
+func TestGetWebTransport_Nothing_HttpTransport(t *testing.T) {
+	transport, err := GetWebTransport("127.0.0.1:90")
+	if err != nil {
+		t.Fatalf("error getting web transport: %v", err)
+	}
+	if transport == nil {
+		t.Error("transport is nil")
+	}
+	if transport.Proxy == nil {
+		t.Error("proxy is nil")
+	}
+	if transport.DialContext != nil {
+		t.Error("dial context is not nil")
+	}
+}
+
+func TestGetWebTransport_Socks5_Socks5Transport(t *testing.T) {
+	transport, err := GetWebTransport("socks5://127.0.0.1")
+	if err != nil {
+		t.Fatalf("error getting web transport: %v", err)
+	}
+	if transport == nil {
+		t.Error("transport is nil")
+	}
+	if transport.Proxy != nil {
+		t.Error("proxy is nil")
+	}
+	if transport.DialContext == nil {
+		t.Error("dial context is nil")
+	}
+}
+
+func TestGetWebTransport_Errors(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expectError   bool
+		errorContains string
+	}{
+		{
+			name:        "Invalid URL syntax",
+			input:       "http://[::1",
+			expectError: true,
+		},
+		{
+			name:          "Unsupported scheme",
+			input:         "ftp://example.com:3128",
+			expectError:   true,
+			errorContains: "unsupported proxy scheme",
+		},
+		{
+			name:        "Broken SOCKS5 URL",
+			input:       "socks5://invalid::proxy",
+			expectError: true,
+		},
+		{
+			name:        "Empty scheme and invalid format",
+			input:       "::::::",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport, err := GetWebTransport(tt.input)
+
+			if tt.expectError && err == nil {
+				t.Errorf("expected error but got nil")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("did not expect error but got: %v", err)
+			}
+			if err != nil && tt.errorContains != "" && !strings.Contains(err.Error(), tt.errorContains) {
+				t.Errorf("expected error to contain %q, got %q", tt.errorContains, err.Error())
+			}
+			if !tt.expectError && transport == nil {
+				t.Errorf("expected non-nil transport, got nil")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Replace fmt.Errorf with errors.New in telegram handler tests to
standardize error creation and simplify imports. Simplify newTestConfig
by directly setting URLs without reflection.

Add comprehensive tests for isValidUrlOrAddr to verify URL and address
validation logic, improving coverage and reliability.

Introduce main_test.go with mocks and tests for flag parsing and HTTP
request handling to increase test coverage and ensure correct
configuration parsing and request behavior.