### PR TITLE
feat: add Telegram bot proxy support and improve concurrency

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -21,8 +21,9 @@ type sitesConfig struct {
 }
 
 type settingsConfig struct {
-	CheckInterval int `toml:"check_interval"`
-	Timeout       int `toml:"timeout"`
+	CheckInterval int    `toml:"check_interval"`
+	Timeout       int    `toml:"timeout"`
+	Proxy         string `toml:"proxy"`
 }
 
 var PathToConfig = "config.toml"

--- a/telegram/TelegramBot.go
+++ b/telegram/TelegramBot.go
@@ -3,33 +3,47 @@ package telegram
 import (
 	tgbotapi "github.com/Syfaro/telegram-bot-api"
 	"log"
+	"net/http"
 )
 
 type TgBot struct {
 	api     *tgbotapi.BotAPI
-	chatID  int64
+	chatId  int64
 	updates chan Update
 }
 
-func NewBot(token string, chatID int) (*TgBot, error) {
+func NewBot(token string, chatId int) (*TgBot, error) {
 	api, err := tgbotapi.NewBotAPI(token)
 	if err != nil {
 		return nil, err
 	}
 
+	return newBotInstance(api, chatId), nil
+}
+
+func NewBotWithProxy(token string, chatId int, client *http.Client) (*TgBot, error) {
+	api, err := tgbotapi.NewBotAPIWithClient(token, client)
+	if err != nil {
+		return nil, err
+	}
+
+	return newBotInstance(api, chatId), nil
+}
+
+func newBotInstance(api *tgbotapi.BotAPI, chatId int) *TgBot {
 	tgBot := &TgBot{
 		api:     api,
-		chatID:  int64(chatID),
+		chatId:  int64(chatId),
 		updates: make(chan Update, 100),
 	}
 
 	go tgBot.listen()
 
-	return tgBot, nil
+	return tgBot
 }
 
 func (bot *TgBot) SendMessage(text string) error {
-	message := tgbotapi.NewMessage(bot.chatID, text)
+	message := tgbotapi.NewMessage(bot.chatId, text)
 	_, err := bot.api.Send(message)
 	return err
 }


### PR DESCRIPTION
- Refactor Telegram bot initialization to try direct connection first,
  then fallback to proxy if direct fails, improving reliability.
- Add proxy configuration support in settings and use it for bot client.
- Adjust wait group usage to match actual goroutines spawned.
- Fix variable shadowing in goroutine to avoid closure capture issues.
- Rename ParseFlags to parseFlags for idiomatic unexported function.
- Add NewBotWithProxy constructor to create Telegram bot with custom HTTP client.
- Minor code cleanup and consistent naming for chatId field.